### PR TITLE
Cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,7 @@
             , processVersion: 2017
             , shortName:      "wot-security-best-practices"
             , copyrightStart: 2017
-            , wg:             "Web of Things Working Group"
-            , wgURI:          "https://www.w3.org/WoT/WG/"
-            , wgPublicList:   "public-wot-wg"
+            , group:          "wg/wot"
             , edDraftURI:     "https://w3c.github.io/wot-security-best-practices/"
             , githubAPI:      "https://api.github.com/repos/w3c/wot-security-best-practices"
             , issueBase:      "https://www.github.com/w3c/wot-security-best-practices/issues"

--- a/index.html
+++ b/index.html
@@ -374,7 +374,7 @@
         Please contribute to this draft using the 
         <a href="https://github.com/w3c/wot-security-best-practices/issues">GitHub Issue</a> 
         feature of the <a href="https://github.com/w3c/wot-security-best-practices/">WoT 
-        Security Best Practices /a> repository.
+        Security Best Practices</a> repository.
       </p>
     </section>
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <link rel="stylesheet" href="tablestyle.css">
     <meta charset="utf-8" />
     <title>Web of Things (WoT) Security Best Practices</title>
-    <script class="remove" async="" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <script class="remove" async="" src="https://www.w3.org/Tools/respec/respec-w3c"></script>
     <script class="remove">
           var respecConfig = {
               specStatus:     "ED"

--- a/index.html
+++ b/index.html
@@ -1009,8 +1009,8 @@
       practices should also be followed for secure update.
       </p><p>
       Good references for best practices for secure update and provisioning
-      are the IIC Security Framework [[IICSF]] and the IoT Security Foundation's
-      guidelines [[IoTSF]].
+      are the IIC Security Framework [[IicSF16]] and the IoT Security Foundation's
+      guidelines [[ISF17]].
       </p>
    </section>
 


### PR DESCRIPTION
resolves https://github.com/w3c/wot-security-best-practices/issues/12

- [x] Add numbered section for intro (fixed markup bug, actually)
- [x] Fix broken references
- [x] Migrate to "respec-w3c" profile (to eliminate warning)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-security-best-practices/pull/20.html" title="Last updated on Jul 21, 2021, 10:51 PM UTC (2112c7e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security-best-practices/20/fd32892...mmccool:2112c7e.html" title="Last updated on Jul 21, 2021, 10:51 PM UTC (2112c7e)">Diff</a>