### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -438,7 +438,10 @@
         the usage of TLS 1.3 with Raw Public Keys as specified in <a href="https://datatracker.ietf.org/doc/html/rfc8446">RFC8446</a> and 
         <a href="https://datatracker.ietf.org/doc/html/rfc7250">RFC7250</a>.
 	      
-	<div class="issue" data-number="/13"></div>
+	<div class="ednote" title="Local Security Best Practices Under Discussion">
+		Best practices for local security are still
+		<a href="https://github.com/w3c/wot-security-best-practices/issues/13">under discussion.</a>
+	 </div>
       </section>
       
     </section>


### PR DESCRIPTION
change "issue" class to "ednote" to get around bug in respec (generating the wrong URL)


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security-best-practices/pull/23.html" title="Last updated on Jul 26, 2021, 1:12 PM UTC (b4255fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security-best-practices/23/b1b4d13...b4255fb.html" title="Last updated on Jul 26, 2021, 1:12 PM UTC (b4255fb)">Diff</a>