### PR TITLE
Update terms and references in Object Security section

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,33 +72,6 @@
                 , publisher: "OCF"
                 , date: "June 2017"
                 },
-                "JWT15": {
-                  href: "https://tools.ietf.org/html/rfc7519"
-                , title: "JSON Web Token (JWT)"
-                , publisher: "IETF"
-                , date: "May 2015"
-                },
-                "CBOR17": {
-                  href: "https://tools.ietf.org/pdf/draft-ietf-ace-cbor-web-token-07.pdf"
-                , title: "CBOR Web Token (CWT)"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "June 2017"
-                },
-                "OSCOAP17": {
-                  href: "https://tools.ietf.org/pdf/draft-ietf-core-object-security-04.pdf"
-                , title: "Object Security of CoAP (OSCOAP)"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "July 2017"
-                },
-                "COSE17": {
-                  href: "https://tools.ietf.org/pdf/draft-ietf-cose-msg-24.pdf"
-                , title: "CBOR Object Signing and Encryption (COSE)"
-                , status:    "Internet-Draft"
-                , publisher: "IETF"
-                , date: "May 2017"
-                },
                 "Bel89": {
                   authors: ["S. Bellovin"]
                 , href: "https://cseweb.ucsd.edu/classes/sp99/cse227/ipext.pdf"

--- a/index.html
+++ b/index.html
@@ -1047,7 +1047,10 @@
       The main advantage of object security is that a compromised Gateway will be 
       prevented from modifying payloads.  
       </p><p>
-      Example object-security standards to consider are COSE [[RFC8152]], and OSCORE [[RFC8613]].
+      Example object-security standards to consider are
+      <abbr title="CBOR Object Signing and Encryption">COSE</abbr> [[RFC8152]], and
+      <abbr title="Object Security for Constrained RESTful Environments">OSCORE</abbr>
+      [[RFC8613]].
       </p>
    </section>
 

--- a/index.html
+++ b/index.html
@@ -1074,7 +1074,7 @@
       The main advantage of object security is that a compromised Gateway will be 
       prevented from modifying payloads.  
       </p><p>
-      Example object-security standards to consider are COSE, OSCORE, and OSCOAP. 
+      Example object-security standards to consider are COSE [[RFC8152]], and OSCORE [[RFC8613]].
       </p>
    </section>
 


### PR DESCRIPTION
Looking through the document, I noticed that there is still OSCOAP being mentioned, which is now a part of OSCORE. I therefore removed OSCOAP and added RFC numbers for OSCORE and COSE.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-security-best-practices/pull/32.html" title="Last updated on Apr 10, 2022, 6:46 PM UTC (42e55f5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-security-best-practices/32/99c4c9f...JKRhb:42e55f5.html" title="Last updated on Apr 10, 2022, 6:46 PM UTC (42e55f5)">Diff</a>